### PR TITLE
Fix IE10

### DIFF
--- a/src/idb.filesystem.js
+++ b/src/idb.filesystem.js
@@ -178,6 +178,7 @@ function MyFile(opts) {
   // Need some black magic to correct the object's size/name/type based on the
   // blob that is saved.
   Object.defineProperty(this, 'blob_', {
+    enumerable: true,
     get: function() {
       return blob_;
     },


### PR DESCRIPTION
As reported in #3 I'll try to fix idb.filesystem.js for IE10.

This first commit only removes the uses of __defineSetter__ and __defineGetter__, I'm still getting a `INVALID_MODIFICATION_ERR` which I've yet to debug, but I wanted input on the following:

Is there a reason you need the getter/setter anyways? Why not use the prototype? [This](https://github.com/ebidel/idb.filesystem.js/blob/master/src/idb.filesystem.js#L169) is the only use of a setter where it's (under my impression) a sensible thing to do; are there problems if the properties are not defined with setters?
