### PR TITLE
Fix getFile when called with create: true and existing file

### DIFF
--- a/src/idb.filesystem.js
+++ b/src/idb.filesystem.js
@@ -554,6 +554,8 @@ DirectoryEntry.prototype.getFile = function(path, options, successCallback,
 
     } else if (options.create === true && fileEntry) {
       if (fileEntry.isFile) {
+        if (!fileEntry.file_)
+          fileEntry.file_ = new MyFile({size: 0, name: fileEntry.name});
         // IDB won't save methods, so we need re-create the FileEntry.
         successCallback(new FileEntry(fileEntry));
       } else {


### PR DESCRIPTION
IE doesn't save methods, so the .file_ property is lost