### PR TITLE
fix truncate() when called with a file that hasn't been written to yet

### DIFF
--- a/src/idb.filesystem.js
+++ b/src/idb.filesystem.js
@@ -216,12 +216,17 @@ function FileWriter(fileEntry) {
   };
 
   this.truncate = function(size) {
-    if (size < this.length) {
-      blob_ = blob_.slice(0, size);
-    } else {
-      blob_ = new Blob([blob_, new Uint8Array(size - this.length)],
+    if (blob_)
+    {
+      if (size < this.length) {
+        blob_ = blob_.slice(0, size);
+      } else {
+        blob_ = new Blob([blob_, new Uint8Array(size - this.length)],
                        {type: blob_.type});
+      }
     }
+    else
+      blob_ = new Blob([]);
 
     position_ = 0; // truncate from beginning of file.
 


### PR DESCRIPTION
e.g., if you do:

getFile(..., function (f)
{
f.truncate(0)
});

Taken by itself, this doesn't make sense to do, but it is valid by the
spec, and in an filesystem API wrapper it can happen
