### PR TITLE
Don't run where indexedDB is not available

### DIFF
--- a/src/idb.filesystem.js
+++ b/src/idb.filesystem.js
@@ -34,8 +34,14 @@ if (exports.requestFileSystem || exports.webkitRequestFileSystem) {
   return;
 }
 
+// Bomb out if no indexedDB available
 var indexedDB = exports.indexedDB || exports.mozIndexedDB ||
                 exports.msIndexedDB;
+if (!indexedDB)
+{
+  return;
+}
+
 exports.TEMPORARY = 0;
 exports.PERSISTENT = 1;
 


### PR DESCRIPTION
For example iOS - this was breaking my phonegap app
