### PR TITLE
Fix and simplify resolveToFullPath_

### DIFF
--- a/src/idb.filesystem.js
+++ b/src/idb.filesystem.js
@@ -106,7 +106,7 @@ var DIR_OPEN_BOUND = String.fromCharCode(DIR_SEPARATOR.charCodeAt(0) + 1);
 // one. This method ensures path is legit!
 function resolveToFullPath_(cwdFullPath, path) {
   var fullPath = path;
-  
+
   var relativePath = path[0] != DIR_SEPARATOR;
   if (relativePath) {
     fullPath = cwdFullPath + DIR_SEPARATOR + path;

--- a/src/idb.filesystem.js
+++ b/src/idb.filesystem.js
@@ -119,8 +119,9 @@ function resolveToFullPath_(cwdFullPath, path) {
     var part = parts[i];
     if (part === '..') {
       // Go up one level.
-      if (!finalParts.length)
+      if (!finalParts.length) {
         throw Error('Invalid path');
+      }
       finalParts.pop();
     } else if (part === '.') {
       // Skip over the current directory.


### PR DESCRIPTION
Bug fixes:

* resolveToFullPath_('/', '.foo') would return '/foo' - not '/.foo'
* resolveToFullPath_('/', 'a/b/../../foo') would return '/a/foo' - not '/foo'
* resolveToFullPath_('/', 'a////b////foo') would return '/a//b//foo' - not '/a/b/foo'
* Some others.

The jsbin for the new version is here: http://jsbin.com/fiqogurowo/2/edit?js,console